### PR TITLE
Remove unused imports in RegexUtilTest

### DIFF
--- a/src/test/java/com/zybzyb/liangyuoj/util/RegexUtilTest.java
+++ b/src/test/java/com/zybzyb/liangyuoj/util/RegexUtilTest.java
@@ -2,9 +2,6 @@ package com.zybzyb.liangyuoj.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.jupiter.api.Test;
 
 


### PR DESCRIPTION
This pull request removes unused imports in the RegexUtilTest class. The unused imports were causing clutter in the code and had no impact on the functionality of the tests. This change improves code readability and maintainability.