### PR TITLE
Fix regex pattern in getClassName method

### DIFF
--- a/src/main/java/com/zybzyb/liangyuoj/util/RegexUtil.java
+++ b/src/main/java/com/zybzyb/liangyuoj/util/RegexUtil.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 
 public class RegexUtil {
     public static String getClassName(String code) {
-        Matcher matcher = Pattern.compile("public\\s+class\\s+(\\w+)\\s*(<.*>)?\\s*\\{")
+        Matcher matcher = Pattern.compile("public\\s+class\\s+(\\w+)\\s*(<.*>)?")
             .matcher(code);
         List<String> res = new ArrayList<>();
         while (matcher.find()) {


### PR DESCRIPTION
This pull request fixes a bug in the `getClassName` method of the `RegexUtil` class. The previous regex pattern used in the method was incorrect and did not capture the class name properly. This PR updates the regex pattern to correctly capture the class name.

Fixes #1234