### PR TITLE
Update work directory path in EvaluateUtil.java

### DIFF
--- a/src/main/java/com/zybzyb/liangyuoj/util/EvaluateUtil.java
+++ b/src/main/java/com/zybzyb/liangyuoj/util/EvaluateUtil.java
@@ -21,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 public class EvaluateUtil {
 
     public static EvaluateResult execute(String sourceCode, String input, String expectedOutput) throws Exception {
-        String workDir = ".\\tests\\";
+        String workDir = "./tests/";
         if (!new File(workDir).exists()) {
             if (new File(workDir).mkdirs()) {
                 log.info("create work directory success");


### PR DESCRIPTION
This pull request updates the work directory path in the EvaluateUtil.java file. The previous path used a backslash (\) as the directory separator, which is not compatible with all operating systems. The updated path now uses a forward slash (/) as the directory separator, which ensures cross-platform compatibility. This change is necessary to ensure that the work directory is created successfully when it does not exist.
