### PR TITLE
Add RootController with redirect to Swagger UI

### DIFF
--- a/src/main/java/com/zybzyb/liangyuoj/LiangyuOjApplication.java
+++ b/src/main/java/com/zybzyb/liangyuoj/LiangyuOjApplication.java
@@ -3,6 +3,10 @@ package com.zybzyb.liangyuoj;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
+
+@OpenAPIDefinition(servers = { @Server(url = "/", description = "Default Server URL") })
 @SpringBootApplication
 public class LiangyuOjApplication {
 

--- a/src/main/java/com/zybzyb/liangyuoj/controller/RootController.java
+++ b/src/main/java/com/zybzyb/liangyuoj/controller/RootController.java
@@ -1,0 +1,25 @@
+package com.zybzyb.liangyuoj.controller;
+
+import java.io.IOException;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.zybzyb.liangyuoj.annotation.NoAuth;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.servlet.http.HttpServletResponse;
+
+@RestController
+@RequestMapping("/")
+@Hidden
+public class RootController {
+    
+    @NoAuth
+    @GetMapping("/")
+    public void root(HttpServletResponse response) throws IOException {
+        response.sendRedirect("/swagger-ui/index.html");
+        return;
+    }
+}


### PR DESCRIPTION
This pull request adds a new RootController class that redirects the root URL to the Swagger UI. This allows users to easily access the API documentation. The RootController class is annotated with @RestController and @RequestMapping("/") to handle requests to the root URL. The root() method in the controller redirects the user to the "/swagger-ui/index.html" URL. This improves the user experience and makes it easier to explore the API documentation.
